### PR TITLE
Only run CI on pull requests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,6 +1,6 @@
 name: Swift
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Because are running out of github actions minutes, don't run CI on every
commit. Only run CI on pull requests.