### PR TITLE
Only process the first touch in drag pan gestures

### DIFF
--- a/Smartpad-iOS/Smartpad-iOS/Controller/DragPanGestureRecognizer.swift
+++ b/Smartpad-iOS/Smartpad-iOS/Controller/DragPanGestureRecognizer.swift
@@ -10,11 +10,12 @@ import UIKit
 
 // Portions of this code follow the apple documentation:
 // https://developer.apple.com/documentation/uikit/touches_presses_and_gestures/implementing_a_custom_gesture_recognizer/implementing_a_discrete_gesture_recognizer
-//
 
 // Custom gesture for longtouch then drag
+// Rules:
 // 1. The user must long touch for 1s
 // 2. The user must pan
+
 class UIDragPanGestureRecognizer:
     UIGestureRecognizer {
     /* Geture states */
@@ -63,23 +64,16 @@ class UIDragPanGestureRecognizer:
         /* Only recognizer 1 finger touches */
         if touches.count != 1 {
             self.state = .failed
+            return
 //            print("Failed, too many touches")
         }
-        else {
-            // Capture the first touch and store some information about it.
-            if self.trackedTouch == nil {
-                self.trackedTouch = touches.first
-                self.initialPos = (self.trackedTouch?.location(in: self.view))!
-                self.startPos = self.initialPos
-            }
-            else {
-               // Ignore all but the first touch.
-               for touch in touches {
-                  if touch != self.trackedTouch {
-                     self.ignore(touch, for: event)
-                  }
-               }
-            }
+
+
+        if self.trackedTouch == nil {
+            /* Capture the first touch and store some information about it. */
+            self.trackedTouch = touches.first
+            self.initialPos = (self.trackedTouch?.location(in: self.view))!
+            self.startPos = self.initialPos
 
             work = DispatchWorkItem(block: {
                 self.currentPhase = .started
@@ -88,6 +82,14 @@ class UIDragPanGestureRecognizer:
 
             /* After 1s, consider the touch to be a "long touch" */
             DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: work!);
+        }
+        else {
+            /* This is not the first touch, ignore all touches except the first one. */
+            for touch in touches {
+                if touch != self.trackedTouch {
+                    self.ignore(touch, for: event)
+                }
+            }
         }
     }
 

--- a/Smartpad-iOS/Smartpad-iOS/Controller/MainViewController.swift
+++ b/Smartpad-iOS/Smartpad-iOS/Controller/MainViewController.swift
@@ -288,11 +288,13 @@ class MainViewController: UIViewController {
 extension MainViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(
       _ gestureRecognizer: UIGestureRecognizer,
-      shouldRecognizeSimultaneouslyWith simultaneousGestureRecognizer: UIGestureRecognizer
+      shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        if ((gestureRecognizer == self.singleTouchGestureRecognizer || gestureRecognizer == self.doubleTouchGestureRecognizer) && (simultaneousGestureRecognizer == self.singleTapGestureRecognizer || simultaneousGestureRecognizer == self.singleTapDoubleClickGestureRecognizer || simultaneousGestureRecognizer == self.doubleTapGestureRecognizer || simultaneousGestureRecognizer == self.singlePanGestureRecognizer || simultaneousGestureRecognizer == self.doublePanGestureRecognizer || simultaneousGestureRecognizer == self.dragPanGestureRecognizer || simultaneousGestureRecognizer == self.pinchGestureRecognizer)) {
+
+        /* Only allow simultaneous gestures when one of the gestures is singleTouch or doubleTouch */
+        if (gestureRecognizer == self.singleTouchGestureRecognizer || gestureRecognizer == self.doubleTouchGestureRecognizer) {
             return true
         }
-      return false
+        return false
     }
 }


### PR DESCRIPTION
There was a bug where we would still arm the drag pan gesture's timer,
even when the touch was not the first one. This would sometimes result
in the recognizer being in a "dirty" state and recognizing the gesture
innapropriately.

Before: Pinching would frequently put the recognizer in the dirty state,
now pinching no longer affects the state of the recognizer